### PR TITLE
add examples folder with cpp file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,21 @@ project (spriteai)
 
 enable_language(CUDA)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.26.0")
+set(LIBTORCH_PATH_DEBUG "${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_debug/libtorch" CACHE FILEPATH "set libtorch debug folder")
+set(LIBTORCH_PATH_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/libs/pytorch_1_13_0_release/libtorch" CACHE FILEPATH "set libtorch release folder")
+set(BUILD_EXAMPLES FALSE CACHE BOOL "build examples")
+
+message("CMAKE_VERSION: ${CMAKE_VERSION}")
+
+if(${CMAKE_VERSION} VERSION_LESS "3.26.0" OR ${CMAKE_VERSION} VERSION_LESS "3.26.0-msvc1")
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CUDA_STANDARD 17)
-  message("cmake version less than 3.26 available. Will use -std17")
+  message("cmake version less than 3.26 available. Will use c++17")
 else()
   if (${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER "12.1.0")
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CUDA_STANDARD 20)
-    message("Cuda 12.1 and cmake 3.26 available. Will use -std20")
+    message("Cuda 12.1 and cmake 3.26 available. Will use c++20")
   else()
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CUDA_STANDARD 17)
@@ -25,10 +31,9 @@ message("Using CUDA Version: ${CMAKE_CUDA_COMPILER_VERSION}")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   message("Build Debug")
-  list(APPEND CMAKE_PREFIX_PATH "libs/pytorch_1_13_0_debug/libtorch/")
+  list(APPEND CMAKE_PREFIX_PATH "${LIBTORCH_PATH_DEBUG}")
   if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     message("Using MSVC")
-    add_compile_options(/Od)
   else ()
     message("Using GCC")
     add_compile_options(-O0 -g)
@@ -36,7 +41,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   endif ()
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   message("Build Release")
-  list(APPEND CMAKE_PREFIX_PATH "libs/pytorch_1_13_0_release/libtorch/")
+  list(APPEND CMAKE_PREFIX_PATH "${LIBTORCH_PATH_RELEASE}")
   if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     message("Using MSVC")
     add_compile_options(/Ot)
@@ -47,7 +52,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWith
   endif ()
 else()
   message("Build Debug")
-  list(APPEND CMAKE_PREFIX_PATH "libs/pytorch_1_13_0_debug/libtorch/")
+  list(APPEND CMAKE_PREFIX_PATH "${LIBTORCH_PATH_DEBUG}")
 endif()
 
 IF (EXISTS ${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_release AND EXISTS ${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_debug)
@@ -55,35 +60,43 @@ IF (EXISTS ${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_release AND EXISTS ${PROJEC
 else()
   message("-- PYTORCH: Pytorch folders missing. Will download them and extract them to libs folder")
   execute_process(
-    COMMAND sh "${PROJECT_SOURCE_DIR}/scripts/libs/getlibs.sh"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/scripts/libs/"
+          COMMAND sh "${PROJECT_SOURCE_DIR}/scripts/libs/getlibs.sh"
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/scripts/libs"
   )
 endif()
 
 find_package(Torch REQUIRED)
-
-add_executable(spriteai
-  capp/main.cpp
-)
-
 message("PYTORCH LIBS: ${TORCH_LIBRARIES}")
 
-target_link_libraries(spriteai
-  ${TORCH_LIBRARIES}
-)
+if (${BUILD_EXAMPLES} )
+add_subdirectory(cexamples/dcgan)
+endif (${BUILD_EXAMPLES})
+
+add_executable(spriteai
+        capp/main.cpp
+        )
+target_link_libraries(${CMAKE_PROJECT_NAME}
+        ${TORCH_LIBRARIES}
+        )
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  target_link_options(${CMAKE_PROJECT_NAME} PUBLIC /DEBUG:FULL)
+endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  FILE(GLOB dllfiles ${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_debug/libtorch/lib/*.dll)
+  FILE(GLOB libtorch_dllfiles "${LIBTORCH_PATH_DEBUG}/lib/*.dll")
   add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-                     COMMAND ${CMAKE_COMMAND} -E copy
-                     ${dllfiles}
-                     ${CMAKE_CURRENT_BINARY_DIR})
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_dllfiles} ${CMAKE_CURRENT_BINARY_DIR})
+
+  FILE(GLOB libtorch_pdbfiles "${LIBTORCH_PATH_DEBUG}/lib/*.pdb")
+  add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_pdbfiles} ${CMAKE_CURRENT_BINARY_DIR})
+
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  FILE(GLOB dllfiles ${PROJECT_SOURCE_DIR}/libs/pytorch_1_13_0_release/libtorch/lib/*.dll)
+  FILE(GLOB libtorch_dllfiles "${LIBTORCH_PATH_RELEASE}/lib/*.dll")
   add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-                     COMMAND ${CMAKE_COMMAND} -E copy
-                     ${dllfiles}
-                     ${CMAKE_CURRENT_BINARY_DIR})
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_dllfiles} ${CMAKE_CURRENT_BINARY_DIR})
 endif ()

--- a/auto_compile.sh
+++ b/auto_compile.sh
@@ -7,20 +7,7 @@ if [[ "$MSYSTEM" != "MINGW64" ]]; then
 	exit 1
 fi
 
-build_type=$1
-pytorch_build_type=$2
-
-if [[ -z $build_type ]]; then
-	build_type="debug"
-fi
-
-echo "build type: $build_type"
-
-if [[ -z $pytorch_build_type ]]; then
-	pytorch_build_type="release"
-fi
-
-echo "build type: $pytorch_build_type"
+build_examples=$1
 
 # create build folder
 
@@ -32,10 +19,12 @@ cd build
 
 # generate amd build
 
-if [ "$pytorch_build_type" == "debug" ]; then
-	cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug ..
+if [[ -z build_examples ]]; then
+  cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=FALSE ..
+  cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=FALSE ..
 else
-	cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release ..
+  cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=TRUE ..
+  cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=TRUE ..
 fi
 
 if [ $? != 0 ]; then
@@ -47,4 +36,5 @@ if [ $? != 0 ]; then
 	fi
 fi
 
-cmake --build . --config $build_type
+cmake --build . --config debug
+cmake --build . --config release

--- a/cexamples/dcgan/CMakeLists.txt
+++ b/cexamples/dcgan/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required (VERSION 3.23.0)
+project (dcgan_example)
+
+enable_language(CUDA)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
+
+find_package(Torch REQUIRED)
+
+add_executable(dcgan_example
+  main.cpp
+)
+
+target_link_libraries(dcgan_example
+  ${TORCH_LIBRARIES}
+)
+
+target_include_directories (dcgan_example PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR})
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  FILE(GLOB libtorch_dllfiles "${LIBTORCH_PATH_DEBUG}/lib/*.dll")
+  add_custom_command(TARGET dcgan_example POST_BUILD
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_dllfiles} ${CMAKE_CURRENT_BINARY_DIR})
+
+  FILE(GLOB libtorch_pdbfiles "${LIBTORCH_PATH_DEBUG}/lib/*.pdb")
+  add_custom_command(TARGET dcgan_example POST_BUILD
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_pdbfiles} ${CMAKE_CURRENT_BINARY_DIR})
+
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  FILE(GLOB libtorch_dllfiles "${LIBTORCH_PATH_RELEASE}/lib/*.dll")
+  add_custom_command(TARGET dcgan_example POST_BUILD
+          WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+          COMMAND ${CMAKE_COMMAND} -E copy ${libtorch_dllfiles} ${CMAKE_CURRENT_BINARY_DIR})
+endif ()

--- a/cexamples/dcgan/main.cpp
+++ b/cexamples/dcgan/main.cpp
@@ -1,0 +1,200 @@
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <cstdint>
+
+#include <torch/torch.h>
+
+// The size of the noise vector fed to the generator.
+const int64_t kNoiseSize = 100;
+
+// The batch size for training.
+const int64_t kBatchSize = 64;
+
+// The number of epochs to train.
+const int64_t kNumberOfEpochs = 30;
+
+// Where to find the MNIST dataset.
+const char* kDataFolder = "./data";
+
+// After how many batches to create a new checkpoint periodically.
+const int64_t kCheckpointEvery = 200;
+
+// How many images to sample at every checkpoint.
+const int64_t kNumberOfSamplesPerCheckpoint = 10;
+
+// Set to `true` to restore models and optimizers from previously saved
+// checkpoints.
+constexpr bool kRestoreFromCheckpoint = false;
+
+// After how many batches to log a new update with the loss value.
+const int64_t kLogInterval = 10;
+
+using namespace torch;
+
+struct [[maybe_unused]] DCGANGeneratorImpl : nn::Module {
+    [[maybe_unused]] explicit DCGANGeneratorImpl(int k_noise_size)
+            : conv1(nn::ConvTranspose2dOptions(k_noise_size, 256, 4)
+                            .bias(false)),
+              batch_norm1(256),
+              conv2(nn::ConvTranspose2dOptions(256, 128, 3)
+                            .stride(2)
+                            .padding(1)
+                            .bias(false)),
+              batch_norm2(128),
+              conv3(nn::ConvTranspose2dOptions(128, 64, 4)
+                            .stride(2)
+                            .padding(1)
+                            .bias(false)),
+              batch_norm3(64),
+              conv4(nn::ConvTranspose2dOptions(64, 1, 4)
+                            .stride(2)
+                            .padding(1)
+                            .bias(false))
+    {
+        // register_module() is needed if we want to use the parameters() method later on
+        register_module("conv1", conv1);
+        register_module("conv2", conv2);
+        register_module("conv3", conv3);
+        register_module("conv4", conv4);
+        register_module("batch_norm1", batch_norm1);
+        register_module("batch_norm2", batch_norm2);
+        register_module("batch_norm3", batch_norm3);
+    }
+
+    torch::Tensor forward(torch::Tensor x) {
+        x = torch::relu(batch_norm1(conv1(x)));
+        x = torch::relu(batch_norm2(conv2(x)));
+        x = torch::relu(batch_norm3(conv3(x)));
+        x = torch::tanh(conv4(x));
+        return x;
+    }
+
+    nn::ConvTranspose2d conv1, conv2, conv3, conv4;
+    nn::BatchNorm2d batch_norm1, batch_norm2, batch_norm3;
+};
+
+TORCH_MODULE(DCGANGenerator);
+
+int main() {
+    torch::manual_seed(1);
+
+    // Create the device we pass around based on whether CUDA is available.
+    torch::Device device(torch::kCPU);
+    if (torch::cuda::is_available()) {
+        std::cout << "CUDA is available! Training on GPU." << std::endl;
+        device = torch::Device(torch::kCUDA);
+    }
+
+    DCGANGenerator generator(kNoiseSize);
+    std::cout << "here" << std::endl;
+    generator->to(device);
+
+    nn::Sequential discriminator(
+            // Layer 1
+            nn::Conv2d(
+                    nn::Conv2dOptions(1, 64, 4).stride(2).padding(1).bias(false)),
+            nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+            // Layer 2
+            nn::Conv2d(
+                    nn::Conv2dOptions(64, 128, 4).stride(2).padding(1).bias(false)),
+            nn::BatchNorm2d(128),
+            nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+            // Layer 3
+            nn::Conv2d(
+                    nn::Conv2dOptions(128, 256, 4).stride(2).padding(1).bias(false)),
+            nn::BatchNorm2d(256),
+            nn::LeakyReLU(nn::LeakyReLUOptions().negative_slope(0.2)),
+            // Layer 4
+            nn::Conv2d(
+                    nn::Conv2dOptions(256, 1, 3).stride(1).padding(0).bias(false)),
+            nn::Sigmoid());
+    discriminator->to(device);
+
+    // Assume the MNIST dataset is available under `kDataFolder`;
+    auto dataset = torch::data::datasets::MNIST(kDataFolder)
+            .map(torch::data::transforms::Normalize<>(0.5, 0.5))
+            .map(torch::data::transforms::Stack<>());
+    const int64_t batches_per_epoch =
+            std::ceil(static_cast<double>(dataset.size().value()) / static_cast<double>(kBatchSize));
+
+    auto data_loader = torch::data::make_data_loader(
+            std::move(dataset),
+            torch::data::DataLoaderOptions().batch_size(kBatchSize).workers(2));
+
+    torch::optim::Adam generator_optimizer(
+            generator->parameters(), torch::optim::AdamOptions(2e-4).betas(std::make_tuple(0.5, 0.5)));
+    torch::optim::Adam discriminator_optimizer(
+            discriminator->parameters(), torch::optim::AdamOptions(2e-4).betas(std::make_tuple(0.5, 0.5)));
+
+#if kRestoreFromCheckpoint
+        torch::load(generator, "generator-checkpoint.pt");
+        torch::load(generator_optimizer, "generator-optimizer-checkpoint.pt");
+        torch::load(discriminator, "discriminator-checkpoint.pt");
+        torch::load(discriminator_optimizer, "discriminator-optimizer-checkpoint.pt");
+#endif
+
+    int64_t checkpoint_counter = 1;
+    for (int64_t epoch = 1; epoch <= kNumberOfEpochs; ++epoch) {
+        int64_t batch_index = 0;
+        for (torch::data::Example<>& batch : *data_loader) {
+            // Train discriminator with real images.
+            discriminator->zero_grad();
+            torch::Tensor real_images = batch.data.to(device);
+            torch::Tensor real_labels = torch::empty(batch.data.size(0), device).uniform_(0.8, 1.0);
+            torch::Tensor real_output = discriminator->forward(real_images).reshape({real_labels.sizes()});
+            torch::Tensor d_loss_real = torch::binary_cross_entropy(real_output, real_labels);
+            d_loss_real.backward();
+
+            // Train discriminator with fake images.
+            torch::Tensor noise =
+                    torch::randn({ batch.data.size(0), kNoiseSize, 1, 1 }, device);
+            torch::Tensor fake_images = generator->forward(noise);
+            torch::Tensor fake_labels = torch::zeros(batch.data.size(0), device);
+            torch::Tensor fake_output = discriminator->forward(fake_images.detach()).reshape({fake_labels.sizes()});
+            torch::Tensor d_loss_fake =
+                    torch::binary_cross_entropy(fake_output, fake_labels);
+            d_loss_fake.backward();
+
+            torch::Tensor d_loss = d_loss_real + d_loss_fake;
+            discriminator_optimizer.step();
+
+            // Train generator.
+            generator->zero_grad();
+            fake_labels.fill_(1);
+            fake_output = discriminator->forward(fake_images).reshape({fake_labels.sizes()});
+            torch::Tensor g_loss =
+                    torch::binary_cross_entropy(fake_output, fake_labels);
+            g_loss.backward();
+            generator_optimizer.step();
+            batch_index++;
+            if (batch_index % kLogInterval == 0) {
+                std::printf("\r[%2lld/%2lld][%3lld/%3lld] D_loss: %.4f | G_loss: %.4f\n"
+                           ,epoch
+                           ,kNumberOfEpochs
+                           ,batch_index
+                           ,batches_per_epoch
+                           ,d_loss.item<float>()
+                           ,g_loss.item<float>());
+            }
+
+            if (batch_index % kCheckpointEvery == 0) {
+                // Checkpoint the model and optimizer state.
+                torch::save(generator, "generator-checkpoint.pt");
+                torch::save(generator_optimizer, "generator-optimizer-checkpoint.pt");
+                torch::save(discriminator, "discriminator-checkpoint.pt");
+                torch::save(
+                        discriminator_optimizer, "discriminator-optimizer-checkpoint.pt");
+                // Sample the generator and save the images.
+                torch::Tensor samples = generator->forward(torch::randn(
+                        { kNumberOfSamplesPerCheckpoint, kNoiseSize, 1, 1 }, device));
+                torch::save(
+                        (samples + 1.0) / 2.0,
+                        torch::str("dcgan-sample-", checkpoint_counter, ".pt"));
+                std::cout << "\n-> checkpoint " << ++checkpoint_counter << '\n';
+            }
+        }
+    }
+
+    std::cout << "Training complete!" << std::endl;
+}


### PR DESCRIPTION
update CMakeLists.txt to copy pdb files to project binary after compile

fix issue with dcgan with the annoying warnings from ATen about reshape mismatching

update auto_compile to generate both debug and release and only have 1 arguement to decide to build the example(s) or not